### PR TITLE
doc: update readme and mention especific RX E2Studio.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,1 @@
+CompileFlags: {CompilationDatabase: HardwareDebug}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ The board is equipped with many communication interfaces, including (but not lim
 
 ## Getting started
 
+### Dependencies setup:
+ 
+- Install the Renesas E2Studio for RX platfrom from: https://www.renesas.com/en/software-tool/e2studio-information-rx-family 
+- Please keep attention, you need the specific software tools for the RX platform, plain E2Studio will not be able to compile it.
+- Additionally you can also use the stand-alone GNU-RX from here: https://llvm-gcc-renesas.com/rx-download-toolchains/
+- After that you can integrate the toolchain using the Renesas Toolchain Manager in the View menu.
+
+
 ### Hardware setup
 - Connect the USB cable to the `Debug` (ECN1) connector, next to the Ethernet port.
 - Set both channels of SW1 (next to ECN1) to OFF

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The board is equipped with many communication interfaces, including (but not lim
 
 ### Dependencies setup:
  
-- Install the Renesas E2Studio for RX platfrom from: https://www.renesas.com/en/software-tool/e2studio-information-rx-family 
+- Install the Renesas E2Studio for RX platform from: https://www.renesas.com/en/software-tool/e2studio-information-rx-family 
 - Keep in mind that you need the specific software tools for the RX platform, plain `E2Studio` will not be able to compile the application.
 - Additionally you can also use the stand-alone GNU-RX from here: https://llvm-gcc-renesas.com/rx-download-toolchains/
 - After that you can select the installed toolchain via the Renesas Toolchain Manager in the View menu.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The board is equipped with many communication interfaces, including (but not lim
 ### Dependencies setup:
  
 - Install the Renesas E2Studio for RX platfrom from: https://www.renesas.com/en/software-tool/e2studio-information-rx-family 
-- Please keep attention, you need the specific software tools for the RX platform, plain E2Studio will not be able to compile it.
+- Keep in mind that you need the specific software tools for the RX platform, plain `E2Studio` will not be able to compile the application.
 - Additionally you can also use the stand-alone GNU-RX from here: https://llvm-gcc-renesas.com/rx-download-toolchains/
-- After that you can integrate the toolchain using the Renesas Toolchain Manager in the View menu.
+- After that you can select the installed toolchain via the Renesas Toolchain Manager in the View menu.
 
 
 ### Hardware setup


### PR DESCRIPTION
Basically the port compile but you need a specific E2Studio for RX that does not comes by default in the latest version, so I added a information for that.

And yes, for dealing with RX and RA processors you may need to live with two installations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the requirement to use the RX-specific Renesas e2 studio and added basic toolchain setup steps in the README. Also added a .clangd config that points clangd to the HardwareDebug compilation database.

- **Dependencies**
  - Install Renesas e2 studio for RX (not the generic install).
  - Optionally install the stand-alone GNU-RX toolchain.
  - Add the toolchain via Renesas Toolchain Manager (View menu).

<sup>Written for commit 915eb85706b670e895ea49566a5e091e258dde7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

